### PR TITLE
Adds Execute Folders

### DIFF
--- a/lib/threequel/executioner.rb
+++ b/lib/threequel/executioner.rb
@@ -13,6 +13,10 @@ module Threequel
       self.new.execute file_path
     end
 
+    def self.execute_folders(folders)
+      self.new.execute_folders folders
+    end
+
     def connection
       ActiveRecord::Base.connection
     end
@@ -32,6 +36,17 @@ module Threequel
       exceptions = opts.delete(:except)
       (ConfigLoader.new(folder_path).tsorted_scripts - [exceptions].flatten).each do |script|
         execute File.join(folder_path, script)
+      end
+    end
+
+    def execute_folders(folders)
+      folders.each do |folder|
+        begin
+          execute_folder(folder)
+        rescue Exception => ex
+          puts ex.message
+          puts ex.backtrace.join("\n")
+        end
       end
     end
   end


### PR DESCRIPTION
Adding a method that wraps and executes the `execute_folder` method,
when passed an array of “folders,” for each entry in the array.

This method differs from the style of `execute_folder` and `execute` by
including basic exception handling.

No existing functionality is altered by the addition of this method.
