### PR TITLE
Canges the logging_handler to raise exceptions

### DIFF
--- a/lib/threequel/logging_handler.rb
+++ b/lib/threequel/logging_handler.rb
@@ -25,6 +25,7 @@ module Threequel
         yield
       end
       loggers.each{ |logger| logger.log stage, timer_attributes.merge(result) }
+      raise result[:message] if result[:status] == :failure
     end
 
   end


### PR DESCRIPTION
This changes the logging process so that if any result hashes are returned that have a status of `:failure` then an exception is raised with the message associated with that status. This is intended to ensure that exceptions propagate up through the logger to the calling function. 
