### PR TITLE
Adds initial log data to logger params

### DIFF
--- a/lib/threequel/logging_handler.rb
+++ b/lib/threequel/logging_handler.rb
@@ -24,7 +24,7 @@ module Threequel
         loggers.each{ |logger| logger.log stage, initial_log_data.merge(:name => name).merge(timer_attributes) }
         yield
       end
-      loggers.each{ |logger| logger.log stage, timer_attributes.merge(result) }
+      loggers.each{ |logger| logger.log stage, initial_log_data.merge(timer_attributes).merge(result) }
       raise result[:message] if result[:status] == :failure
     end
 


### PR DESCRIPTION
Adds the `initial_log_data` hash back to the params passed to the
logger handler. It looks like this line was removed erroneously by a
previous merge.
