### PR TITLE
Changes logging_handler to propogate up the return value

### DIFF
--- a/lib/threequel/logging_handler.rb
+++ b/lib/threequel/logging_handler.rb
@@ -25,7 +25,10 @@ module Threequel
         yield
       end
       loggers.each{ |logger| logger.log stage, initial_log_data.merge(timer_attributes).merge(result) }
+
       raise result[:message] if result[:status] == :failure
+
+      result
     end
 
   end


### PR DESCRIPTION
of the yielded method.

This is necessary because the `execute_on` method of the
`Command` class expects the return value of the `execute_on`
of the `Statement` class.

@blankenshipz was the mastermind of this change
