### PR TITLE
Consider the connection used to execute sql dirty

### DIFF
--- a/lib/threequel/executioner.rb
+++ b/lib/threequel/executioner.rb
@@ -17,24 +17,26 @@ module Threequel
       self.new.execute_folders folders
     end
 
-    def connection
-      ActiveRecord::Base.connection_pool.checkout
+   def with_connection(&block)
+      connection = ActiveRecord::Base.connection_pool.checkout
+
+      yield connection
+    ensure
+      connection.reconnect!
+      ActiveRecord::Base.connection_pool.checkin(connection)
     end
 
     def execute(path)
-      script             = Script.new(path)
-      current_connection = connection
+      script = Script.new(path)
 
-      command = SQL::Command.new(script.code, path, {}) do |config|
-        config.extend(Threequel::Logging)
-        config.add_logging_to :execute_on, :db, :console
+      with_connection do |current_connection|
+        command = SQL::Command.new(script.code, path, {}) do |config|
+          config.extend(Threequel::Logging)
+          config.add_logging_to :execute_on, :db, :console
+        end
+
+        command.execute_on(current_connection)
       end
-
-      command.execute_on(current_connection)
-
-      current_connection.reconnect!
-
-      ActiveRecord::Base.connection_pool.checkin(current_connection)
     end
 
     def execute_folder(folder_path, opts = {})


### PR DESCRIPTION
This prevents connections in the `ActiveRecord::Base` connection
pool from losing the appropriate db context by:
- checking out the connection used to execute arbitrary statements so
  that other objects can't use the dirty connection
- using `reconnect` before checking the connection back into the pool
  so that the connection is 'clean' before it's used again

Per #13 
